### PR TITLE
Support the upcoming TZInfo v2.0.0 release

### DIFF
--- a/spec/time_spec.rb
+++ b/spec/time_spec.rb
@@ -71,17 +71,38 @@ describe EtOrbi::EoTime do
 
   describe '#to_time (protected)' do
 
-    it 'returns a local Time instance, although with a UTC zone' do
+    if TZInfo::Timezone.get('America/Los_Angeles').utc_to_local(Time.at(1193898300)).utc?
+      # TZInfo < 2.0.0
 
-      ot = EtOrbi::EoTime.new(1193898300, 'America/Los_Angeles')
-      t = ot.send(:to_time)
+      it 'returns a local Time instance, although with a UTC zone' do
 
-      expect(ot.to_debug_s).to eq('ot 2007-10-31 23:25:00 -08:00 dst:true')
+        ot = EtOrbi::EoTime.new(1193898300, 'America/Los_Angeles')
+        t = ot.send(:to_time)
 
-      expect(t.to_i).to eq(1193898300 - 7 * 3600) # /!\
+        expect(ot.to_debug_s).to eq('ot 2007-10-31 23:25:00 -08:00 dst:true')
 
-      expect(t.to_debug_s).to eq('t 2007-10-31 23:25:00 +00:00 dst:false')
-        # Time instance stuck to UTC...
+        expect(t.to_i).to eq(1193898300 - 7 * 3600) # /!\
+
+        expect(t.to_debug_s).to eq('t 2007-10-31 23:25:00 +00:00 dst:false')
+          # Time instance stuck to UTC...
+      end
+
+    else
+      # TZInfo >= 2.0.0
+
+      it 'returns a local Time instance' do
+
+        ot = EtOrbi::EoTime.new(1193898300, 'America/Los_Angeles')
+        t = ot.send(:to_time)
+
+        expect(ot.to_debug_s).to eq('ot 2007-10-31 23:25:00 -08:00 dst:true')
+
+        expect(t.to_i).to eq(1193898300)
+        expect(t.utc_offset).to eq(-7 * 3600)
+
+        expect(t.to_debug_s).to eq('t 2007-10-31 23:25:00 -07:00 dst:true')
+      end
+
     end
   end
 


### PR DESCRIPTION
I'm the maintainer of the tzinfo gem. et-orbi currently depends on tzinfo with open-ended version constraints.

I'm working on a new major release of tzinfo (v2.0.0), which I hope to release sometime in the coming months. This will break backwards compatibility in a few ways that affect et-orbi:

- The `TimezonePeriod#to_local` and `TimezonePeriod#to_utc` methods have been removed. `Timezone#utc_to_local` and `Timezone#local_to_utc` should be used instead.
- `TZInfo::TransitionDataTimezoneInfo` has been replaced with `TZInfo::DataSources::ConstantOffsetDataTimezoneInfo` and `TZInfo::DataSources::TransitionsDataTimezoneInfo`.
- Methods that return local times (such as `Timezone#utc_to_local`) now return results using the appropriate local UTC offset instead of always using UTC.

This pull request includes changes that make et-orbi compatible with both the upcoming tzinfo v2.0.0 release and existing tzinfo releases.

To test with the current development version of tzinfo instead of a released version, you can add the following line to the `Gemfile`:

```ruby
gem 'tzinfo', git: 'https://github.com/tzinfo/tzinfo.git'
```