### PR TITLE
Handle Rails Duration types

### DIFF
--- a/lib/et-orbi/time.rb
+++ b/lib/et-orbi/time.rb
@@ -205,7 +205,8 @@ module EtOrbi
 
     def ==(o)
 
-      o.is_a?(EoTime) &&
+      o = Rufus::Scheduler.parse(o)
+
       o.seconds == @seconds &&
       (o.zone == @zone || o.zone.current_period == @zone.current_period)
     end


### PR DESCRIPTION
It'd be nice to handle Rails Durations for comparisons here since as it stands, it doesn't support comparisons with user provided Time objects. Could we do something like this, please? 