### PR TITLE
Filter out only allowed options for Chronic

### DIFF
--- a/lib/et-orbi/make.rb
+++ b/lib/et-orbi/make.rb
@@ -12,7 +12,7 @@ module EtOrbi
 
       str, str_zone = extract_zone(str)
 
-      if defined?(::Chronic) && opts.fetch(:enable_chronic, true) && t = ::Chronic.parse(str, opts)
+      if defined?(::Chronic) && opts.fetch(:enable_chronic, true) && t = ::Chronic.parse(str, chronic_opts(opts))
 
         str = [ t.strftime('%F %T'), str_zone ].compact.join(' ')
       end
@@ -59,6 +59,10 @@ module EtOrbi
     alias make make_time
 
     protected
+
+    def chronic_opts(opts)
+      opts.slice(*Chronic::Parser::DEFAULT_OPTIONS.keys)
+    end
 
     def make_from_time(t, zone)
 


### PR DESCRIPTION
As of https://github.com/mojombo/chronic/pull/269, the `master` version
of Chronic validates all options. By default, et-orbi passes in `zone`,
which causes `Chronic::Parser` to fail.