### PR TITLE
GitHub is HTTPS by default

### DIFF
--- a/et-orbi.gemspec
+++ b/et-orbi.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.platform = Gem::Platform::RUBY
   s.authors = [ 'John Mettraux' ]
   s.email = [ 'jmettraux+flor@gmail.com' ]
-  s.homepage = 'http://github.com/floraison/et-orbi'
+  s.homepage = 'https://github.com/floraison/et-orbi'
   s.license = 'MIT'
   s.summary = 'time with zones'
 


### PR DESCRIPTION
This reduces unnecessary redirection from http://... to https://... when someone visits this gem's homepage via https://rubygems.org/gems/et-orbi or some tools or APIs that use the gem's metadata.