### PR TITLE
Add Ruby 3.1 and JRuby 9.3 to the CI matrix

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest ]
-        ruby: [ '2.3', '2.5', '2.6', '2.7', '3.0', jruby-9.2 ]
+        ruby: [ '2.3', '2.5', '2.6', '2.7', '3.0', '3.1', jruby-9.2, jruby-9.3 ]
         experimental: [ false ]
         tz: [ '', 'UTC', 'Asia/Tokyo', 'America/Chicago' ]
       fail-fast: false


### PR DESCRIPTION
This PR adds Ruby 3.1 and JRuby 9.3 to the CI matrix.  No other changes.  Everything runs green.