### PR TITLE
remove version parsing in gemspec

### DIFF
--- a/et-orbi.gemspec
+++ b/et-orbi.gemspec
@@ -1,12 +1,9 @@
 
+require_relative 'lib/et-orbi/version'
+
 Gem::Specification.new do |s|
-
   s.name = 'et-orbi'
-
-  s.version = File.read(
-    File.expand_path('../lib/et-orbi.rb', __FILE__)
-  ).match(/ VERSION *= *['"]([^'"]+)/)[1]
-
+  s.version = EtOrbi::VERSION
   s.platform = Gem::Platform::RUBY
   s.authors = [ 'John Mettraux' ]
   s.email = [ 'jmettraux+flor@gmail.com' ]

--- a/lib/et-orbi.rb
+++ b/lib/et-orbi.rb
@@ -4,15 +4,9 @@ require 'time'
 
 require 'tzinfo'
 
+require 'et-orbi/version'
 require 'et-orbi/info'
 require 'et-orbi/make'
 require 'et-orbi/time'
 require 'et-orbi/zones'
 require 'et-orbi/zone'
-
-
-module EtOrbi
-
-  VERSION = '1.3.0'
-end
-

--- a/lib/et-orbi/version.rb
+++ b/lib/et-orbi/version.rb
@@ -1,0 +1,3 @@
+module EtOrbi
+  VERSION = '1.3.0'
+end


### PR DESCRIPTION
I've seen this pattern across gems.
Not sure if it is of interest to you. (if not, no worries).

Looking forward to version 1.3.0. (we have a monkeypatch in our code right now handling the addition case)

Thanks for the great rufus-scheduler gem