### PR TITLE
Use UTC instead of Zulu

### DIFF
--- a/lib/et-orbi/zone.rb
+++ b/lib/et-orbi/zone.rb
@@ -8,7 +8,7 @@ module EtOrbi
       return o if o.is_a?(::TZInfo::Timezone)
       return nil if o == nil
       return determine_local_tzone if o == :local
-      return ::TZInfo::Timezone.get('Zulu') if o == 'Z'
+      return ::TZInfo::Timezone.get('UTC') if o == 'Z'
       return o.tzinfo if o.respond_to?(:tzinfo)
 
       o = to_offset(o) if o.is_a?(Numeric)

--- a/test/module_test.rb
+++ b/test/module_test.rb
@@ -406,7 +406,7 @@ group EtOrbi do
       'Europe/Zurich' => 'Europe/Zurich',
       'W-SU' => 'W-SU',
 
-      'Z' => 'Zulu',
+      'Z' => 'UTC',
 
       '+09:00' => '+09:00',
       '-01:30' => '-01:30',


### PR DESCRIPTION
`tzdata` package on ubuntu 24.04 (and probably newer) doesn't carry the definition for `Zulu` anymore.

On 24.04
```
# apt info tzdata
Package: tzdata
Version: 2026c-0ubuntu0.24.04.1
-----B<-----SNIP-----B<-----

# dpkg-query -L tzdata | grep -e Zulu -e UTC
/usr/share/zoneinfo/Etc/UTC
/usr/share/zoneinfo/Etc/Zulu
/usr/share/zoneinfo/UTC
```

On 22.04
```
# apt info tzdata
Package: tzdata
Version: 2026c-0ubuntu0.22.04.1

# dpkg-query -L tzdata | grep -e Zulu -e UTC
/usr/share/zoneinfo/Etc/UTC
/usr/share/zoneinfo/posix/Etc/UTC
/usr/share/zoneinfo/right/Etc/UTC
/usr/share/zoneinfo/Etc/Zulu
/usr/share/zoneinfo/UTC
/usr/share/zoneinfo/Zulu
/usr/share/zoneinfo/posix/Etc/Zulu
/usr/share/zoneinfo/posix/UTC
/usr/share/zoneinfo/posix/Zulu
/usr/share/zoneinfo/right/Etc/Zulu
/usr/share/zoneinfo/right/UTC
/usr/share/zoneinfo/right/Zulu
```